### PR TITLE
Fix Linux play command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Once downloaded, your model folder should look like this:
 ## Playing
 
 - Windows: double-click `play.bat`
-- Linux: `sh play.sh`
+- Linux: `bash play.sh`
 - OS-agnostic install: `python launch.py`
 
 


### PR DESCRIPTION
Some Linux distros don't use bash for /bin/sh, which may cause the script to not work, so bash is now explicitly specified.